### PR TITLE
Handle page overflow

### DIFF
--- a/lib/demo_web/live/table_live.ex
+++ b/lib/demo_web/live/table_live.ex
@@ -99,7 +99,7 @@ defmodule DemoWeb.TableLive do
 
   defp number_of_pages(%{data: data, query: query, page_size: page_size}) do
     number_of_rows = data |> filter(query) |> length
-    number_of_rows / page_size |> trunc
+    (number_of_rows / page_size) + 1 |> trunc
   end
 
   defp sort_order_icon(column, sort_by, :asc) when column == sort_by, do: "▲"


### PR DESCRIPTION
I had a page with 12 items. When the page size was set to 10, it would only show one page due to the number of rows being divided by the page size then truncating. Adding one 1 the number of rows / page size before truncating should fix the issue.